### PR TITLE
chore: release v0.1.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.0"
+  "version": "v0.1.1"
 }


### PR DESCRIPTION
Release v0.1.1 doesn't include any code change, but updates the module name to use the new Github org name.