### PR TITLE
fix: bitstr comparison panic

### DIFF
--- a/kad/key/bitstr/key.go
+++ b/kad/key/bitstr/key.go
@@ -57,14 +57,14 @@ func (k Key) CommonPrefixLength(o Key) int {
 		if len(o) == 0 && k.isZero() {
 			return len(k)
 		}
-		panic(lengthPanicMsg)
 	}
-	for i := 0; i < len(k); i++ {
+	minLen := min(len(k), len(o))
+	for i := range minLen {
 		if k[i] != o[i] {
 			return i
 		}
 	}
-	return len(k)
+	return minLen
 }
 
 func (k Key) Compare(o Key) int {
@@ -75,9 +75,8 @@ func (k Key) Compare(o Key) int {
 		if len(o) == 0 && k.isZero() {
 			return 0
 		}
-		panic(lengthPanicMsg)
 	}
-	for i := 0; i < len(k); i++ {
+	for i := range min(len(k), len(o)) {
 		if k[i] != o[i] {
 			if k[i] < o[i] {
 				return -1
@@ -85,7 +84,13 @@ func (k Key) Compare(o Key) int {
 			return 1
 		}
 	}
-	return 0
+	if len(k) == len(o) {
+		return 0
+	}
+	if len(k) > len(o) {
+		return 1
+	}
+	return -1
 }
 
 func (k Key) isZero() bool {

--- a/kad/key/util.go
+++ b/kad/key/util.go
@@ -15,6 +15,9 @@ const BitPanicMsg = "bit index out of range"
 
 // Equal reports whether two keys have equal numeric values.
 func Equal[K kad.Key[K]](a, b K) bool {
+	if a.BitLen() != b.BitLen() {
+		return false
+	}
 	return a.Compare(b) == 0
 }
 


### PR DESCRIPTION
Don't panic on `bitstr.Key` `CommonPrefixLength` and `Compare` if both keys don't have the same bit length.