### PR TITLE
feat(trie): AddMany

### DIFF
--- a/kad/trie/trie.go
+++ b/kad/trie/trie.go
@@ -62,7 +62,7 @@ func (tr *Trie[K, D]) IsEmptyLeaf() bool {
 	return !tr.HasKey() && tr.IsLeaf()
 }
 
-// IsEmptyLeaf reports whether the Trie is a leaf node without branches but has a key.
+// IsNonEmptyLeaf reports whether the Trie is a leaf node without branches but has a key.
 func (tr *Trie[K, D]) IsNonEmptyLeaf() bool {
 	return tr.HasKey() && tr.IsLeaf()
 }

--- a/kad/trie/trie.go
+++ b/kad/trie/trie.go
@@ -97,33 +97,75 @@ func (tr *Trie[K, D]) shrink() {
 // Add attempts to add a key to the trie, mutating the trie.
 // Returns true if the key was added, false otherwise.
 func (tr *Trie[K, D]) Add(kk K, data D) bool {
-	return tr.addAtDepth(0, kk, data)
+	return tr.addManyAtDepth(0, Entry[K, D]{Key: kk, Data: data}) == 1
 }
 
-func (tr *Trie[K, D]) addAtDepth(depth int, kk K, data D) bool {
-	switch {
-	case tr.IsEmptyLeaf():
-		tr.key = &kk
-		tr.data = data
-		return true
-	case tr.IsNonEmptyLeaf():
-		if key.Equal(*tr.key, kk) {
-			return false
-		} else {
-			p := tr.key // non-nil since IsNonEmptyLeaf
+// AddMany attempts to add multiple entries to the trie, mutating the trie.
+// Returns the number of entries that were successfully added.
+// Duplicate keys within entries or keys already in the trie are ignored.
+func (tr *Trie[K, D]) AddMany(entries ...Entry[K, D]) int {
+	return tr.addManyAtDepth(0, entries...)
+}
+
+func (tr *Trie[K, D]) addManyAtDepth(depth int, entries ...Entry[K, D]) int {
+	if len(entries) == 0 {
+		return 0
+	}
+
+	// Partition entries by direction
+	sortedEntries := [2][]Entry[K, D]{}
+	for i := range entries {
+		if entries[i].Key.BitLen() <= depth {
+			// Ignore keys that are too short, it means the node already exists in
+			// trie, but isn't a leaf.
+			continue
+		}
+		b := entries[i].Key.Bit(depth)
+		sortedEntries[b] = append(sortedEntries[b], entries[i])
+	}
+
+	if tr.IsLeaf() {
+		if tr.HasKey() {
+			// Check if any entry matches existing key
+			if len(entries) == 1 && key.Equal(*tr.key, entries[0].Key) {
+				// Key already exists
+				return 0
+			}
+
+			b := int((*tr.key).Bit(depth))
+			// Split this leaf into branches
+			p := tr.key
 			d := tr.data
 			tr.key = nil
 			var v D
 			tr.data = v
-			// both branches are nil
 			tr.branch[0], tr.branch[1] = &Trie[K, D]{}, &Trie[K, D]{}
-			tr.branch[(*p).Bit(depth)].key = p
-			tr.branch[(*p).Bit(depth)].data = d
-			return tr.branch[kk.Bit(depth)].addAtDepth(depth+1, kk, data)
+			tr.branch[b].key = p
+			tr.branch[b].data = d
+		} else {
+			if len(entries) == 1 {
+				tr.key = &entries[0].Key
+				tr.data = entries[0].Data
+				return 1
+			}
+			// Create branches to distribute entries
+			tr.branch[0], tr.branch[1] = &Trie[K, D]{}, &Trie[K, D]{}
 		}
-	default:
-		return tr.branch[kk.Bit(depth)].addAtDepth(depth+1, kk, data)
 	}
+	added := 0
+	for i, branchEntries := range sortedEntries {
+		for range len(branchEntries) - 1 {
+			// Lazily removes duplicates
+			if !key.Equal(branchEntries[0].Key, branchEntries[len(branchEntries)-1].Key) {
+				break
+			}
+			branchEntries = branchEntries[:len(branchEntries)-1]
+		}
+		if len(branchEntries) > 0 {
+			added += tr.branch[i].addManyAtDepth(depth+1, branchEntries...)
+		}
+	}
+	return added
 }
 
 // Add adds the key to trie, returning a new trie if the key was not already in the trie.

--- a/kad/trie/trie_test.go
+++ b/kad/trie/trie_test.go
@@ -202,6 +202,233 @@ func TestAddIgnoresDuplicates(t *testing.T) {
 	}
 }
 
+func TestAddManyEmpty(t *testing.T) {
+	tr := New[kadtest.Key32, int]()
+
+	entries := []Entry[kadtest.Key32, int]{
+		{Key: kadtest.Key32(0x10000000), Data: 1},
+		{Key: kadtest.Key32(0x20000000), Data: 2},
+		{Key: kadtest.Key32(0x30000000), Data: 3},
+	}
+
+	added := tr.AddMany(entries...)
+	require.Equal(t, 3, added)
+	require.Equal(t, 3, tr.Size())
+
+	// Verify all keys are findable
+	for _, e := range entries {
+		found, data := Find(tr, e.Key)
+		require.True(t, found)
+		require.Equal(t, e.Data, data)
+	}
+
+	if d := CheckInvariant(tr); d != nil {
+		t.Fatalf("trie invariant discrepancy: %v", d)
+	}
+}
+
+func TestAddManySingle(t *testing.T) {
+	tr := New[kadtest.Key32, int]()
+
+	entries := []Entry[kadtest.Key32, int]{
+		{Key: kadtest.Key32(0x10000000), Data: 42},
+	}
+
+	added := tr.AddMany(entries...)
+	require.Equal(t, 1, added)
+	require.Equal(t, 1, tr.Size())
+
+	found, data := Find(tr, entries[0].Key)
+	require.True(t, found)
+	require.Equal(t, 42, data)
+
+	if d := CheckInvariant(tr); d != nil {
+		t.Fatalf("trie invariant discrepancy: %v", d)
+	}
+}
+
+func TestAddManyWithDuplicatesInNewEntries(t *testing.T) {
+	tr := New[kadtest.Key32, int]()
+
+	// Multiple entries with the same key
+	entries := []Entry[kadtest.Key32, int]{
+		{Key: kadtest.Key32(0x10000000), Data: 1},
+		{Key: kadtest.Key32(0x20000000), Data: 2},
+		{Key: kadtest.Key32(0x10000000), Data: 100}, // duplicate
+		{Key: kadtest.Key32(0x30000000), Data: 3},
+		{Key: kadtest.Key32(0x20000000), Data: 200}, // duplicate
+	}
+
+	added := tr.AddMany(entries...)
+
+	// Should add unique keys only
+	require.Equal(t, 3, added)
+	require.Equal(t, 3, tr.Size())
+
+	// First occurrence should win (based on lazy dedup logic)
+	found, data := Find(tr, kadtest.Key32(0x10000000))
+	require.True(t, found)
+	require.Equal(t, 1, data)
+
+	found, data = Find(tr, kadtest.Key32(0x20000000))
+	require.True(t, found)
+	require.Equal(t, 2, data)
+
+	if d := CheckInvariant(tr); d != nil {
+		t.Fatalf("trie invariant discrepancy: %v", d)
+	}
+}
+
+func TestAddManyWithKeysAlreadyInTrie(t *testing.T) {
+	tr := New[kadtest.Key32, int]()
+
+	// Pre-populate trie
+	existing := []Entry[kadtest.Key32, int]{
+		{Key: kadtest.Key32(0x10000000), Data: 100},
+		{Key: kadtest.Key32(0x20000000), Data: 200},
+	}
+	for _, e := range existing {
+		tr.Add(e.Key, e.Data)
+	}
+	require.Equal(t, 2, tr.Size())
+
+	// Try to add mix of new and existing keys
+	entries := []Entry[kadtest.Key32, int]{
+		{Key: kadtest.Key32(0x10000000), Data: 1}, // already exists
+		{Key: kadtest.Key32(0x30000000), Data: 3}, // new
+		{Key: kadtest.Key32(0x20000000), Data: 2}, // already exists
+		{Key: kadtest.Key32(0x40000000), Data: 4}, // new
+		{Key: kadtest.Key32(0x20000000), Data: 5}, // already exists
+		{Key: kadtest.Key32(0x20000000), Data: 6}, // already exists
+	}
+
+	added := tr.AddMany(entries...)
+
+	// Should only add the 2 new keys
+	require.Equal(t, 2, added)
+	require.Equal(t, 4, tr.Size())
+
+	// Existing keys should keep their original data
+	found, data := Find(tr, kadtest.Key32(0x10000000))
+	require.True(t, found)
+	require.Equal(t, 100, data) // original data preserved
+
+	found, data = Find(tr, kadtest.Key32(0x20000000))
+	require.True(t, found)
+	require.Equal(t, 200, data) // original data preserved
+
+	// New keys should be added
+	found, data = Find(tr, kadtest.Key32(0x30000000))
+	require.True(t, found)
+	require.Equal(t, 3, data)
+
+	found, data = Find(tr, kadtest.Key32(0x40000000))
+	require.True(t, found)
+	require.Equal(t, 4, data)
+
+	if d := CheckInvariant(tr); d != nil {
+		t.Fatalf("trie invariant discrepancy: %v", d)
+	}
+}
+
+func TestAddManyOnlyDuplicates(t *testing.T) {
+	tr := New[kadtest.Key32, int]()
+
+	key := kadtest.Key32(0x10000000)
+	tr.Add(key, 42)
+	require.Equal(t, 1, tr.Size())
+
+	// Try to add only the existing key
+	entries := []Entry[kadtest.Key32, int]{
+		{Key: key, Data: 100},
+	}
+
+	added := tr.AddMany(entries...)
+	require.Equal(t, 0, added)
+	require.Equal(t, 1, tr.Size())
+
+	// Data should be unchanged
+	found, data := Find(tr, key)
+	require.True(t, found)
+	require.Equal(t, 42, data)
+
+	if d := CheckInvariant(tr); d != nil {
+		t.Fatalf("trie invariant discrepancy: %v", d)
+	}
+}
+
+func TestAddManyIsOrderIndependent(t *testing.T) {
+	for _, s := range newKeySetList(10) {
+		entries := make([]Entry[kadtest.Key32, int], len(s.Keys))
+		for i, k := range s.Keys {
+			entries[i] = Entry[kadtest.Key32, int]{Key: k, Data: i}
+		}
+
+		base := New[kadtest.Key32, int]()
+		base.AddMany(entries...)
+		if d := CheckInvariant(base); d != nil {
+			t.Fatalf("base trie invariant discrepancy: %v", d)
+		}
+
+		for range 10 {
+			perm := rand.Perm(len(entries))
+			reorderedEntries := make([]Entry[kadtest.Key32, int], len(entries))
+			for i := range entries {
+				reorderedEntries[i] = entries[perm[i]]
+			}
+
+			reordered := New[kadtest.Key32, int]()
+			reordered.AddMany(reorderedEntries...)
+			if d := CheckInvariant(reordered); d != nil {
+				t.Fatalf("reordered trie invariant discrepancy: %v", d)
+			}
+
+			// Note: Equal doesn't check data, so we verify size and lookups
+			require.Equal(t, base.Size(), reordered.Size())
+			for _, k := range s.Keys {
+				foundBase, _ := Find(base, k)
+				foundReordered, _ := Find(reordered, k)
+				require.Equal(t, foundBase, foundReordered)
+			}
+		}
+	}
+}
+
+func TestAddManyLarge(t *testing.T) {
+	tr := New[kadtest.Key32, int]()
+
+	n := 100
+	entries := make([]Entry[kadtest.Key32, int], 0, n)
+	seen := make(map[string]bool)
+
+	for i := 0; len(entries) < n; i++ {
+		k := kadtest.RandomKey()
+		if seen[k.String()] {
+			continue
+		}
+		seen[k.String()] = true
+		entries = append(entries, Entry[kadtest.Key32, int]{
+			Key:  k,
+			Data: i,
+		})
+	}
+
+	added := tr.AddMany(entries...)
+	require.Equal(t, n, added)
+	require.Equal(t, n, tr.Size())
+
+	// Verify all keys are findable
+	for _, e := range entries {
+		found, data := Find(tr, e.Key)
+		require.True(t, found)
+		require.Equal(t, e.Data, data)
+	}
+
+	if d := CheckInvariant(tr); d != nil {
+		t.Fatalf("trie invariant discrepancy: %v", d)
+	}
+}
+
 func TestImmutableAddIgnoresDuplicates(t *testing.T) {
 	tr := New[kadtest.Key32, any]()
 	var err error

--- a/kad/trie/trie_test.go
+++ b/kad/trie/trie_test.go
@@ -113,7 +113,7 @@ func TestAddIsOrderIndependent(t *testing.T) {
 		if d := CheckInvariant(base); d != nil {
 			t.Fatalf("base trie invariant discrepancy: %v", d)
 		}
-		for j := 0; j < 100; j++ {
+		for range 100 {
 			perm := rand.Perm(len(s.Keys))
 			reordered := New[kadtest.Key32, any]()
 			for i := range s.Keys {
@@ -138,7 +138,7 @@ func TestImmutableAddIsOrderIndependent(t *testing.T) {
 		if d := CheckInvariant(base); d != nil {
 			t.Fatalf("base trie invariant discrepancy: %v", d)
 		}
-		for j := 0; j < 100; j++ {
+		for range 100 {
 			perm := rand.Perm(len(s.Keys))
 			reordered := New[kadtest.Key32, any]()
 			for i := range s.Keys {
@@ -568,7 +568,7 @@ func TestRemoveUnknown(t *testing.T) {
 	}
 	require.Equal(t, len(sampleKeySet.Keys), tr.Size())
 
-	unknown := newKeyNotInSet(sampleKeySet.Keys[0].BitLen(), sampleKeySet)
+	unknown := newKeyNotInSet(sampleKeySet)
 
 	removed := tr.Remove(unknown)
 	require.False(t, removed)
@@ -586,7 +586,7 @@ func TestImmutableRemoveUnknown(t *testing.T) {
 	}
 	require.Equal(t, len(sampleKeySet.Keys), tr.Size())
 
-	unknown := newKeyNotInSet(sampleKeySet.Keys[0].BitLen(), sampleKeySet)
+	unknown := newKeyNotInSet(sampleKeySet)
 
 	trNext, err := Remove(tr, unknown)
 	require.NoError(t, err)
@@ -610,7 +610,7 @@ func TestEqual(t *testing.T) {
 	}
 	require.True(t, Equal(a, b))
 
-	sampleKeySet2 := newKeySetOfLength(12, 64)
+	sampleKeySet2 := newKeySetOfLength(12)
 	c, err := trieFromKeys[kadtest.Key32, any](sampleKeySet2.Keys)
 	if err != nil {
 		t.Fatalf("unexpected error during from keys: %v", err)
@@ -784,7 +784,7 @@ func BenchmarkFindNegative(b *testing.B) {
 func benchmarkBuildTrieMutable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		b.ResetTimer()
@@ -802,7 +802,7 @@ func benchmarkBuildTrieMutable(n int) func(b *testing.B) {
 func benchmarkBuildTrieImmutable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		b.ResetTimer()
@@ -820,7 +820,7 @@ func benchmarkBuildTrieImmutable(n int) func(b *testing.B) {
 func benchmarkAddMutable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		tr := New[kadtest.Key32, any]()
@@ -852,7 +852,7 @@ func benchmarkAddMutable(n int) func(b *testing.B) {
 func benchmarkAddImmutable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		trBase := New[kadtest.Key32, any]()
@@ -879,7 +879,7 @@ func benchmarkAddImmutable(n int) func(b *testing.B) {
 func benchmarkRemoveMutable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		tr := New[kadtest.Key32, any]()
@@ -911,7 +911,7 @@ func benchmarkRemoveMutable(n int) func(b *testing.B) {
 func benchmarkRemoveImmutable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		trBase := New[kadtest.Key32, any]()
@@ -938,7 +938,7 @@ func benchmarkRemoveImmutable(n int) func(b *testing.B) {
 func benchmarkFindPositive(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		tr := New[kadtest.Key32, any]()
@@ -956,7 +956,7 @@ func benchmarkFindPositive(n int) func(b *testing.B) {
 func benchmarkFindNegative(n int) func(b *testing.B) {
 	return func(b *testing.B) {
 		keys := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = kadtest.RandomKey()
 		}
 		tr := New[kadtest.Key32, any]()
@@ -964,7 +964,7 @@ func benchmarkFindNegative(n int) func(b *testing.B) {
 			tr, _ = Add(tr, kk, nil)
 		}
 		unknown := make([]kadtest.Key32, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			kk := kadtest.RandomKey()
 			if found, _ := Find(tr, kk); found {
 				continue
@@ -984,17 +984,17 @@ type keySet struct {
 	Keys []kadtest.Key32
 }
 
-var sampleKeySet = newKeySetOfLength(12, 64)
+var sampleKeySet = newKeySetOfLength(12)
 
 func newKeySetList(n int) []*keySet {
 	s := make([]*keySet, n)
 	for i := range s {
-		s[i] = newKeySetOfLength(31, 32)
+		s[i] = newKeySetOfLength(31)
 	}
 	return s
 }
 
-func newKeySetOfLength(n int, bits int) *keySet {
+func newKeySetOfLength(n int) *keySet {
 	set := make([]kadtest.Key32, 0, n)
 	seen := make(map[string]bool)
 	for len(set) < n {
@@ -1010,7 +1010,7 @@ func newKeySetOfLength(n int, bits int) *keySet {
 	}
 }
 
-func newKeyNotInSet(bits int, ks *keySet) kadtest.Key32 {
+func newKeyNotInSet(ks *keySet) kadtest.Key32 {
 	seen := make(map[string]bool)
 	for i := range ks.Keys {
 		seen[ks.Keys[i].String()] = true
@@ -1128,10 +1128,10 @@ func (p *triePath[K]) bitString(depthToLeaf int) string {
 	if p == nil {
 		return ""
 	} else {
-		switch {
-		case p.bit == 0:
+		switch p.bit {
+		case 0:
 			return p.parent.bitString(depthToLeaf+1) + "0"
-		case p.bit == 1:
+		case 1:
 			return p.parent.bitString(depthToLeaf+1) + "1"
 		default:
 			panic("bit digit > 1")


### PR DESCRIPTION
`AddMany` adds multiple entries to the trie.

`AddMany` is much more efficient than iterating on the items and adding them sequentially, since this requires to traverse the trie multiple times.

`AddMany` splits the keys in `left` and `right` at each depth, allowing to insert many keys and limiting the number of trie traversals.