### PR TITLE
feat(key/bit256): memory optimized constructor

### DIFF
--- a/kad/key/bit256/key.go
+++ b/kad/key/bit256/key.go
@@ -1,3 +1,4 @@
+// Package bit256 provides a 256-bit Kademlia key implementation.
 package bit256
 
 import (
@@ -65,7 +66,7 @@ func (Key) BitLen() int {
 func (k Key) Xor(o Key) Key {
 	var xored [KeyLen]byte
 	if k.b != nil && o.b != nil {
-		for i := 0; i < KeyLen; i++ {
+		for i := range KeyLen {
 			xored[i] = k.b[i] ^ o.b[i]
 		}
 	} else if k.b != nil && o.b == nil {
@@ -82,7 +83,7 @@ func (k Key) CommonPrefixLength(o Key) int {
 		return 256
 	}
 	var x byte
-	for i := 0; i < KeyLen; i++ {
+	for i := range KeyLen {
 		x = k.b[i] ^ o.b[i]
 		if x != 0 {
 			return i*8 + 7 - int(math.Log2(float64(x))) // TODO: make this more efficient

--- a/kad/key/bit256/key.go
+++ b/kad/key/bit256/key.go
@@ -29,6 +29,12 @@ func NewKey(data []byte) Key {
 	return Key{b: &b}
 }
 
+// NewKeyFromArray creates a Key from a 32-byte array without intermediate copying.
+// This is more efficient than NewKey when the caller already has a [32]byte array.
+func NewKeyFromArray(arr [KeyLen]byte) Key {
+	return Key{b: &arr}
+}
+
 // ZeroKey returns a 256-bit Kademlia key with all bits zeroed.
 func ZeroKey() Key {
 	var b [KeyLen]byte

--- a/kad/key/bit256/key_test.go
+++ b/kad/key/bit256/key_test.go
@@ -15,7 +15,7 @@ func TestKey(t *testing.T) {
 		Key1: NewKey(append(make([]byte, 31), 0x01)),
 
 		// key2 is key0 + 2 (00000...010)
-		Key2: NewKey(append(make([]byte, 31), 0x02)),
+		Key2: NewKeyFromArray([32]byte{31: 0x02}),
 
 		// key1xor2 is key1 ^ key2 (00000...011)
 		Key1xor2: NewKey(append(make([]byte, 31), 0x03)),
@@ -24,7 +24,7 @@ func TestKey(t *testing.T) {
 		Key100: NewKey(append([]byte{0x80}, make([]byte, 31)...)),
 
 		// key010 is key0 with the second most significant bit set (01000...000)
-		Key010: NewKey(append([]byte{0x40}, make([]byte, 31)...)),
+		Key010: NewKeyFromArray([32]byte{0: 0x40}),
 
 		KeyX: NewKey(append([]byte{0x23, 0xe4, 0xdd, 0x03}, make([]byte, 28)...)),
 	}


### PR DESCRIPTION
`bit256.NewKey()` accepts a slice (variable size), and needs to copy the bytes to an array before allocating to the heap.

If caller already has an array (`[32]byte`), it can now be passed directly to `bit256.NewKeyFromArray()` for increased efficiency.