### PR TITLE
chore: update pkg path to ipfs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-libdht
 
 [![ProbeLab](https://img.shields.io/badge/made%20by-ProbeLab-blue.svg)](https://probelab.io)
-[![GoDoc](https://pkg.go.dev/badge/github.com/probe-lab/go-libdht)](https://pkg.go.dev/github.com/probe-lab/go-libdht)
-[![Build status](https://img.shields.io/github/actions/workflow/status/probe-lab/go-libdht/go-test.yml?branch=main)](https://github.com/probe-lab/go-libdht/actions)
+[![GoDoc](https://pkg.go.dev/badge/github.com/ipfs/go-libdht)](https://pkg.go.dev/github.com/ipfs/go-libdht)
+[![Build status](https://img.shields.io/github/actions/workflow/status/ipfs/go-libdht/go-test.yml?branch=main)](https://github.com/ipfs/go-libdht/actions)
 
 `go-libdht` is a generic toolbox designed for the implementation and experimentation of Distributed Hash Tables (DHT) in Go. It establishes foundational types and interfaces applicable across a broad spectrum of DHTs, especially those sharing a similar topology. By offering reusable components like keys and routing tables, `go-libdht` streamlines the DHT implementation process. Using `go-libdht`, developers can seamlessly craft their own DHTs using the provided modular components.
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/probe-lab/go-libdht
+module github.com/ipfs/go-libdht
 
 go 1.23
 

--- a/kad/kadtest/ids.go
+++ b/kad/kadtest/ids.go
@@ -3,9 +3,9 @@ package kadtest
 import (
 	"crypto/sha256"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/key"
-	"github.com/probe-lab/go-libdht/kad/key/bit256"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad/key/bit256"
 )
 
 // ID is a concrete implementation of the NodeID interface.

--- a/kad/kadtest/key.go
+++ b/kad/kadtest/key.go
@@ -3,7 +3,7 @@ package kadtest
 import (
 	"fmt"
 
-	"github.com/probe-lab/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad"
 )
 
 const bitPanicMsg = "bit index out of range"

--- a/kad/kadtest/key_test.go
+++ b/kad/kadtest/key_test.go
@@ -3,7 +3,7 @@ package kadtest
 import (
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad/key/test"
+	"github.com/ipfs/go-libdht/kad/key/test"
 )
 
 func TestKey32(t *testing.T) {

--- a/kad/kadtest/rand.go
+++ b/kad/kadtest/rand.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 
-	"github.com/probe-lab/go-libdht/kad/key/bit256"
+	"github.com/ipfs/go-libdht/kad/key/bit256"
 )
 
 var rng = rand.New(rand.NewSource(299792458))

--- a/kad/key/bit256/key.go
+++ b/kad/key/bit256/key.go
@@ -6,8 +6,8 @@ import (
 	"encoding/hex"
 	"math"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/key"
 )
 
 // KeyLen is the length of a 256-bit key in bytes.

--- a/kad/key/bit256/key_test.go
+++ b/kad/key/bit256/key_test.go
@@ -3,7 +3,7 @@ package bit256
 import (
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad/key/test"
+	"github.com/ipfs/go-libdht/kad/key/test"
 )
 
 func TestKey(t *testing.T) {

--- a/kad/key/bitstr/key.go
+++ b/kad/key/bitstr/key.go
@@ -1,8 +1,8 @@
 package bitstr
 
 import (
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/key"
 )
 
 // Key is a binary key represented by a string of 1's and 0's

--- a/kad/key/bitstr/key_test.go
+++ b/kad/key/bitstr/key_test.go
@@ -3,7 +3,7 @@ package bitstr
 import (
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad/key/test"
+	"github.com/ipfs/go-libdht/kad/key/test"
 )
 
 // TestBitStrKey7 tests a strange 7-bit Kademlia key

--- a/kad/key/test/keytest.go
+++ b/kad/key/test/keytest.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/key"
 
 	"github.com/stretchr/testify/require"
 )

--- a/kad/key/test/util_test.go
+++ b/kad/key/test/util_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad/key"
-	"github.com/probe-lab/go-libdht/kad/key/bit256"
-	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+	"github.com/ipfs/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad/key/bit256"
+	"github.com/ipfs/go-libdht/kad/key/bitstr"
 	"github.com/stretchr/testify/require"
 )
 

--- a/kad/key/util.go
+++ b/kad/key/util.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/probe-lab/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad"
 )
 
 // ErrInvalidDataLength is the error returned when attempting to construct a key from binary data of the wrong length.

--- a/kad/trie/trie.go
+++ b/kad/trie/trie.go
@@ -4,8 +4,8 @@ package trie
 import (
 	"slices"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/key"
 )
 
 // Trie is a trie for equal-length bit vectors, which stores values only in the leaves.

--- a/kad/trie/trie_test.go
+++ b/kad/trie/trie_test.go
@@ -4,9 +4,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/kadtest"
-	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/kadtest"
+	"github.com/ipfs/go-libdht/kad/key"
 
 	"github.com/stretchr/testify/require"
 )

--- a/kad/triert/config.go
+++ b/kad/triert/config.go
@@ -1,7 +1,7 @@
 package triert
 
 import (
-	"github.com/probe-lab/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad"
 )
 
 // Config holds configuration options for a TrieRT.

--- a/kad/triert/filter.go
+++ b/kad/triert/filter.go
@@ -1,6 +1,6 @@
 package triert
 
-import "github.com/probe-lab/go-libdht/kad"
+import "github.com/ipfs/go-libdht/kad"
 
 // KeyFilterFunc is a function that is applied before a key is added to the table.
 // Return false to prevent the key from being added.

--- a/kad/triert/filter_test.go
+++ b/kad/triert/filter_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad/kadtest"
+	"github.com/ipfs/go-libdht/kad/kadtest"
 	"github.com/stretchr/testify/require"
 )
 

--- a/kad/triert/table.go
+++ b/kad/triert/table.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/kadtest"
-	"github.com/probe-lab/go-libdht/kad/key/bit256"
-	"github.com/probe-lab/go-libdht/kad/trie"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/kadtest"
+	"github.com/ipfs/go-libdht/kad/key/bit256"
+	"github.com/ipfs/go-libdht/kad/trie"
 )
 
 // TrieRT is a routing table backed by a XOR Trie which offers good scalablity and performance

--- a/kad/triert/table_test.go
+++ b/kad/triert/table_test.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/probe-lab/go-libdht/kad"
-	"github.com/probe-lab/go-libdht/kad/kadtest"
-	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/ipfs/go-libdht/kad"
+	"github.com/ipfs/go-libdht/kad/kadtest"
+	"github.com/ipfs/go-libdht/kad/key"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Transferred from `github.com/probe-lab/go-libdht` to `github.com/ipfs/go-libdht`